### PR TITLE
Changes to fix algebraic representation

### DIFF
--- a/chess.py
+++ b/chess.py
@@ -442,19 +442,19 @@ class King(Piece):
             if all(
                     self.board.get_piece_at(Location(
                         algebraic=loc)) is Board.empty
-                    for loc in [f"f{self.row + 1}", f"g{self.row + 1}"]):
+                    for loc in [f"f{8 - self.row}", f"g{8 - self.row}"]):
                 if not self.moving_into_check(
-                        Location(algebraic=f"f{self.row + 1}")):
-                    yield Location(algebraic=f"g{self.row + 1}")
+                        Location(algebraic=f"f{8 - self.row}")):
+                    yield Location(algebraic=f"g{8 - self.row}")
 
         if "q" in relevant_castling_rights:
             if all(
                     self.board.get_piece_at(Location(
                         algebraic=loc)) is Board.empty for loc in
-                [f"b{self.row + 1}", f"c{self.row + 1}", f"d{self.row + 1}"]):
+                [f"b{8 - self.row}", f"c{8 - self.row}", f"d{8 - self.row}"]):
                 if not self.moving_into_check(
-                        Location(algebraic=f"d{self.row + 1}")):
-                    yield Location(algebraic=f"c{self.row + 1}")
+                        Location(algebraic=f"d{8 - self.row}")):
+                    yield Location(algebraic=f"c{8 - self.row}")
 
 
 class Queen(Piece):

--- a/chess.py
+++ b/chess.py
@@ -45,7 +45,7 @@ class Location:
         def idx_to_letter(idx: int) -> str:
             return chr(idx + 97)
 
-        return idx_to_letter(row_col[1]) + str(row_col[0] + 1)
+        return idx_to_letter(row_col[1]) + str(8 - row_col[0])
 
     @classmethod
     def row_col_from_algebraic(cls, algebraic: str) -> tuple:
@@ -53,7 +53,7 @@ class Location:
         def letter_to_idx(ltr: str) -> int:
             return ord(ltr) - 97
 
-        return (int(algebraic[1:]) - 1, letter_to_idx(algebraic[0]))
+        return (8 - int(algebraic[1:]), letter_to_idx(algebraic[0]))
 
     @property
     def in_bounds(self) -> bool:
@@ -302,7 +302,7 @@ class Board:
     def __str__(self) -> str:
         """ Return a human readable string displaying the board."""
         str_rep = "   a b c d e f g h\n"
-        i = 1
+        i = 8
         for row in self.board_rep:
             str_rep += str(i) + "  "
             for piece in row:
@@ -312,7 +312,7 @@ class Board:
                     str_rep += str(piece)
                 str_rep += " "
             str_rep += " " + str(i) + "\n"
-            i += 1
+            i -= 1
         str_rep += "   a b c d e f g h"
         return str_rep
 

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ TODO:
         - game should end properly with the 50 move draw rule
     - test that the halfmove clock and fullmove number are updated appropriately
     - test that fullmove and halmove counters are updated correctly
-    - test that the game ends if either playter is in check mate
+    - test that the game ends if either player is in check mate
     - test that 'i' can not move into check
     - test that the game ends if the half move counter reaches 100
     - make sure to update castling rights after moving a king or a castle
@@ -26,14 +26,14 @@ def test():
     >>> b = Board()
     >>> print(b)
        a b c d e f g h
-    1  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  ♟ ♟ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  _ _ _ _ _ _ _ _  4
-    5  _ _ _ _ _ _ _ _  5
+    8  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  ♟ ♟ ♟ ♟ ♟ ♟ ♟ ♟  7
     6  _ _ _ _ _ _ _ _  6
-    7  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ ♘ ♗ ♕ ♔ ♗ ♘ ♖  8
+    5  _ _ _ _ _ _ _ _  5
+    4  _ _ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ ♘ ♗ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> b.fen_str
     'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
@@ -44,76 +44,76 @@ def test():
     >>> b.who.name
     'WHITE'
     >>> try:
-    ...     b.make_move(Location(algebraic='b2'), Location(algebraic='b3'))
+    ...     b.make_move(Location(algebraic='b7'), Location(algebraic='b6'))
     ... except IllegalMoveError as e:
     ...     print(e)
     It is white\'s turn and white does not control the selected piece. Please select a valid piece to move.
     >>> try:
-    ...     b.make_move(Location(algebraic='a4'), Location(algebraic='a5'))
+    ...     b.make_move(Location(algebraic='a5'), Location(algebraic='a4'))
     ... except IllegalMoveError as e:
     ...     print(e)
     Cannot make a move from an empty square. Please select a valid piece to move.
-    >>> b.make_move(Location(algebraic='b8'), Location(algebraic='c6'))
+    >>> b.make_move(Location(algebraic='b1'), Location(algebraic='c3'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  ♟ ♟ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
+    8  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  ♟ ♟ ♟ ♟ ♟ ♟ ♟ ♟  7
+    6  _ _ _ _ _ _ _ _  6
+    5  _ _ _ _ _ _ _ _  5
     4  _ _ _ _ _ _ _ _  4
-    5  _ _ _ _ _ _ _ _  5
-    6  _ _ ♘ _ _ _ _ _  6
-    7  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
+    3  _ _ ♘ _ _ _ _ _  3
+    2  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> b.make_move(Location(algebraic='a2'), Location(algebraic='a4'))
+    >>> b.make_move(Location(algebraic='a7'), Location(algebraic='a5'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ ♟ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ _ _ _ _ _ _  4
-    5  _ _ _ _ _ _ _ _  5
-    6  _ _ ♘ _ _ _ _ _  6
-    7  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
-       a b c d e f g h
-    >>> b.make_move(Location(algebraic='c6'), Location(algebraic='a5'))
-    >>> print(b)
-       a b c d e f g h
-    1  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ ♟ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ _ _ _ _ _ _  4
-    5  ♘ _ _ _ _ _ _ _  5
+    8  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ ♟ ♟ ♟ ♟ ♟ ♟ ♟  7
     6  _ _ _ _ _ _ _ _  6
-    7  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
+    5  ♟ _ _ _ _ _ _ _  5
+    4  _ _ _ _ _ _ _ _  4
+    3  _ _ ♘ _ _ _ _ _  3
+    2  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> b.make_move(Location(algebraic='b2'), Location(algebraic='b4'))
+    >>> b.make_move(Location(algebraic='c3'), Location(algebraic='a4'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ ♟ _ _ _ _ _ _  4
-    5  ♘ _ _ _ _ _ _ _  5
+    8  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ ♟ ♟ ♟ ♟ ♟ ♟ ♟  7
     6  _ _ _ _ _ _ _ _  6
-    7  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
+    5  ♟ _ _ _ _ _ _ _  5
+    4  ♘ _ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> pawn = b.get_piece_at(Location(algebraic='b4'))
+    >>> b.make_move(Location(algebraic='b7'), Location(algebraic='b5'))
+    >>> print(b)
+       a b c d e f g h
+    8  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ ♟ ♟ ♟ ♟  7
+    6  _ _ _ _ _ _ _ _  6
+    5  ♟ ♟ _ _ _ _ _ _  5
+    4  ♘ _ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
+       a b c d e f g h
+    >>> pawn = b.get_piece_at(Location(algebraic='b5'))
     >>> [move.algebraic for move in pawn.all_legal_moves]
-    ['b5', 'a5']
-    >>> kn = b.get_piece_at(Location(algebraic='a5'))
+    ['b4', 'a4']
+    >>> kn = b.get_piece_at(Location(algebraic='a4'))
     >>> [move.algebraic for move in kn.all_legal_moves]
-    ['c6', 'c4', 'b3']
+    ['c3', 'c5', 'b6']
     >>> try:
-    ...     b.make_move(Location(algebraic='a5'), Location(algebraic='a6'))
+    ...     b.make_move(Location(algebraic='a4'), Location(algebraic='a3'))
     ... except IllegalMoveError as e:
     ...     print(e)
     Move is not legal
     >>> try:
-    ...     b.make_move(Location(algebraic='a5'), Location(algebraic='a42'))
+    ...     b.make_move(Location(algebraic='a4'), Location(algebraic='a52'))
     ... except IllegalMoveError as e:
     ...     print(e)
     Cannot move outside the boundaries of the board. Please select a different destination.
@@ -121,237 +121,237 @@ def test():
     >>> b2 = Board(fen_str)
     >>> print(b2)
        a b c d e f g h
-    1  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ ♟ _ _ _ _ _ _  4
-    5  ♘ _ _ _ _ _ _ _  5
+    8  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ ♟ ♟ ♟ ♟  7
     6  _ _ _ _ _ _ _ _  6
-    7  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
+    5  ♟ ♟ _ _ _ _ _ _  5
+    4  ♘ _ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> try:
-    ...     b.make_move(Location(algebraic='b7'), Location(algebraic='b4'))
+    ...     b.make_move(Location(algebraic='b2'), Location(algebraic='b5'))
     ... except:
     ...     print('illegal move')
     illegal move
-    >>> b.make_move(Location(algebraic='b7'), Location(algebraic='b5')); print(b)
+    >>> b.make_move(Location(algebraic='b2'), Location(algebraic='b4')); print(b)
        a b c d e f g h
-    1  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ ♟ _ _ _ _ _ _  4
-    5  ♘ ♙ _ _ _ _ _ _  5
+    8  ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ ♟ ♟ ♟ ♟  7
     6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
+    5  ♟ ♟ _ _ _ _ _ _  5
+    4  ♘ ♙ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
+    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='c1')).all_legal_moves))
+    ['b2', 'a3']
+    >>> try:
+    ...     b.make_move(Location(algebraic='b8'), Location(algebraic='b7'))
+    ... except IllegalMoveError as e:
+    ...     print(e)
+    Move is not legal
     >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='c8')).all_legal_moves))
     ['b7', 'a6']
+    >>> b.make_move(Location(algebraic='b8'), Location(algebraic='c6')); print(b)
+       a b c d e f g h
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ ♟ ♟ ♟ ♟  7
+    6  _ _ ♞ _ _ _ _ _  6
+    5  ♟ ♟ _ _ _ _ _ _  5
+    4  ♘ ♙ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ ♙ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
+       a b c d e f g h
+    >>> b.make_move(Location(algebraic='d2'), Location(algebraic='d4')); print(b)
+       a b c d e f g h
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ ♟ ♟ ♟ ♟  7
+    6  _ _ ♞ _ _ _ _ _  6
+    5  ♟ ♟ _ _ _ _ _ _  5
+    4  ♘ ♙ _ ♙ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
+       a b c d e f g h
+    >>> b.en_passant_target.algebraic
+    'd3'
+    >>> b.who = Color.WHITE
+    >>> b.make_move(Location(algebraic='d4'), Location(algebraic='d5')); print(b)
+       a b c d e f g h
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ ♟ ♟ ♟ ♟  7
+    6  _ _ ♞ _ _ _ _ _  6
+    5  ♟ ♟ _ ♙ _ _ _ _  5
+    4  ♘ ♙ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
+       a b c d e f g h
+    >>> b.make_move(Location(algebraic='e7'), Location(algebraic='e5')); print(b)
+       a b c d e f g h
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
+    6  _ _ ♞ _ _ _ _ _  6
+    5  ♟ ♟ _ ♙ ♟ _ _ _  5
+    4  ♘ ♙ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ ♙ ♙ ♙  2
+    1  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  1
+       a b c d e f g h
+    >>> b.fen_str
+    'r1bqkbnr/2pp1ppp/2n5/pp1Pp3/NP6/8/P1P1PPPP/R1BQKBNR w KQkq e6 0 5'
+    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='d5')).all_legal_moves))
+    ['d6', 'e6', 'c6']
     >>> try:
-    ...     b.make_move(Location(algebraic='b1'), Location(algebraic='b2'))
+    ...     b.make_move(Location(algebraic='d5'), Location(algebraic='d5'))
+    ... except IllegalMoveError as e:
+    ...     print(e)
+    Move is not legal
+    >>> try:
+    ...     b.make_move(Location(algebraic='a4'), Location(algebraic='a4'))
+    ... except IllegalMoveError as e:
+    ...     print(e)
+    Move is not legal
+    >>> try:
+    ...     b.make_move(Location(algebraic='c1'), Location(algebraic='c1'))
     ... except IllegalMoveError as e:
     ...     print(e)
     Move is not legal
     >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='c1')).all_legal_moves))
-    ['b2', 'a3']
-    >>> b.make_move(Location(algebraic='b1'), Location(algebraic='c3')); print(b)
+    ['d2', 'e3', 'f4', 'g5', 'h6', 'b2', 'a3']
+    >>> b.make_move(Location(algebraic='c1'), Location(algebraic='f4')); print(b)
        a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ ♞ _ _ _ _ _  3
-    4  ♟ ♟ _ _ _ _ _ _  4
-    5  ♘ ♙ _ _ _ _ _ _  5
-    6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ ♙ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
+    6  _ _ ♞ _ _ _ _ _  6
+    5  ♟ ♟ _ ♙ ♟ _ _ _  5
+    4  ♘ ♙ _ _ _ ♗ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ ♙ ♙ ♙  2
+    1  ♖ _ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> b.make_move(Location(algebraic='d7'), Location(algebraic='d5')); print(b)
-       a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ ♞ _ _ _ _ _  3
-    4  ♟ ♟ _ _ _ _ _ _  4
-    5  ♘ ♙ _ ♙ _ _ _ _  5
-    6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
-       a b c d e f g h
-    >>> b.en_passant_target.algebraic
-    'd6'
+    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='f4')).all_legal_moves))
+    ['g3', 'e3', 'd2', 'c1', 'g5', 'h6', 'e5']
     >>> b.who = Color.WHITE
-    >>> b.make_move(Location(algebraic='d5'), Location(algebraic='d4')); print(b)
+    >>> b.make_move(Location(algebraic='f4'), Location(algebraic='e5')); print(b)
        a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ ♟ ♟ ♟ ♟  2
-    3  _ _ ♞ _ _ _ _ _  3
-    4  ♟ ♟ _ ♙ _ _ _ _  4
-    5  ♘ ♙ _ _ _ _ _ _  5
-    6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
-       a b c d e f g h
-    >>> b.make_move(Location(algebraic='e2'), Location(algebraic='e4')); print(b)
-       a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ ♞ _ _ _ _ _  3
-    4  ♟ ♟ _ ♙ ♟ _ _ _  4
-    5  ♘ ♙ _ _ _ _ _ _  5
-    6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ ♙ ♙ ♙  7
-    8  ♖ _ ♗ ♕ ♔ ♗ ♘ ♖  8
-       a b c d e f g h
-    >>> b.fen_str
-    'r1bqkbnr/2pp1ppp/2n5/pp1Pp3/NP6/8/P1P1PPPP/R1BQKBNR w KQkq e3 0 5'
-    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='d4')).all_legal_moves))
-    ['d3', 'e3', 'c3']
-    >>> try:
-    ...     b.make_move(Location(algebraic='d4'), Location(algebraic='d4'))
-    ... except IllegalMoveError as e:
-    ...     print(e)
-    Move is not legal
-    >>> try:
-    ...     b.make_move(Location(algebraic='a5'), Location(algebraic='a5'))
-    ... except IllegalMoveError as e:
-    ...     print(e)
-    Move is not legal
-    >>> try:
-    ...     b.make_move(Location(algebraic='c8'), Location(algebraic='c8'))
-    ... except IllegalMoveError as e:
-    ...     print(e)
-    Move is not legal
-    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='c8')).all_legal_moves))
-    ['d7', 'e6', 'f5', 'g4', 'h3', 'b7', 'a6']
-    >>> b.make_move(Location(algebraic='c8'), Location(algebraic='f5')); print(b)
-       a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ ♞ _ _ _ _ _  3
-    4  ♟ ♟ _ ♙ ♟ _ _ _  4
-    5  ♘ ♙ _ _ _ ♗ _ _  5
-    6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ ♙ ♙ ♙  7
-    8  ♖ _ _ ♕ ♔ ♗ ♘ ♖  8
-       a b c d e f g h
-    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='f5')).all_legal_moves))
-    ['g6', 'e6', 'd7', 'c8', 'g4', 'h3', 'e4']
-    >>> b.who = Color.WHITE
-    >>> b.make_move(Location(algebraic='f5'), Location(algebraic='e4')); print(b)
-       a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ ♞ _ _ _ _ _  3
-    4  ♟ ♟ _ ♙ ♗ _ _ _  4
-    5  ♘ ♙ _ _ _ _ _ _  5
-    6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ ♙ ♙ ♙  7
-    8  ♖ _ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
+    6  _ _ ♞ _ _ _ _ _  6
+    5  ♟ ♟ _ ♙ ♗ _ _ _  5
+    4  ♘ ♙ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ ♙ ♙ ♙  2
+    1  ♖ _ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> b.castling_rights
     ['K', 'Q', 'k', 'q']
     >>> b.half_move_clock
     0
     >>> try:
-    ...     b.make_move(Location(algebraic='b4'), Location(algebraic='b6'))
-    ... except IllegalMoveError as e:
-    ...     print(e)
-    Move is not legal
-    >>> b.make_move(Location(algebraic='b4'), Location(algebraic='a5')); print(b)
-       a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ ♞ _ _ _ _ _  3
-    4  ♟ _ _ ♙ ♗ _ _ _  4
-    5  ♟ ♙ _ _ _ _ _ _  5
-    6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ ♙ ♙ ♙  7
-    8  ♖ _ _ ♕ ♔ ♗ ♘ ♖  8
-       a b c d e f g h
-    >>> try:
     ...     b.make_move(Location(algebraic='b5'), Location(algebraic='b3'))
     ... except IllegalMoveError as e:
     ...     print(e)
     Move is not legal
-    >>> b.who = Color.WHITE
-    >>> b.make_move(Location(algebraic='f7'), Location(algebraic='f5'))
-    >>> b.en_passant_target.algebraic
-    'f6'
+    >>> b.make_move(Location(algebraic='b5'), Location(algebraic='a4')); print(b)
+       a b c d e f g h
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
+    6  _ _ ♞ _ _ _ _ _  6
+    5  ♟ _ _ ♙ ♗ _ _ _  5
+    4  ♟ ♙ _ _ _ _ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ ♙ ♙ ♙  2
+    1  ♖ _ _ ♕ ♔ ♗ ♘ ♖  1
+       a b c d e f g h
     >>> try:
-    ...     b.make_move(Location(algebraic='c3'), Location(algebraic='c4'))
+    ...     b.make_move(Location(algebraic='b4'), Location(algebraic='b6'))
     ... except IllegalMoveError as e:
     ...     print(e)
     Move is not legal
-    >>> b.make_move(Location(algebraic='c3'), Location(algebraic='e4')); print(b)
+    >>> b.who = Color.WHITE
+    >>> b.make_move(Location(algebraic='f2'), Location(algebraic='f4'))
+    >>> b.en_passant_target.algebraic
+    'f3'
+    >>> try:
+    ...     b.make_move(Location(algebraic='c6'), Location(algebraic='c5'))
+    ... except IllegalMoveError as e:
+    ...     print(e)
+    Move is not legal
+    >>> b.make_move(Location(algebraic='c6'), Location(algebraic='e5')); print(b)
        a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ _ ♙ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ _  5
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
     6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ _ ♙ ♙  7
-    8  ♖ _ _ ♕ ♔ ♗ ♘ ♖  8
+    5  ♟ _ _ ♙ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ _ ♙ ♙  2
+    1  ♖ _ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> b.en_passant_target.algebraic
     '-'
-    >>> ##b.get_piece_at(Location(algebraic='a8')).all_legal_moves
-    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='a8')).all_legal_moves))
-    ['b8', 'c8']
-    >>> b.make_move(Location(algebraic='a8'), Location(algebraic='b8'))
+    >>> ##b.get_piece_at(Location(algebraic='a1')).all_legal_moves
+    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='a1')).all_legal_moves))
+    ['b1', 'c1']
+    >>> b.make_move(Location(algebraic='a1'), Location(algebraic='b1'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ _ ♙ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ _  5
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
     6  _ _ _ _ _ _ _ _  6
-    7  ♙ _ ♙ _ ♙ _ ♙ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    5  ♟ _ _ ♙ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ _  4
+    3  _ _ _ _ _ _ _ _  3
+    2  ♙ _ ♙ _ ♙ _ ♙ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='b8')).all_legal_moves))
-    ['b7', 'b6', 'a8', 'c8']
+    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='b1')).all_legal_moves))
+    ['b2', 'b3', 'a1', 'c1']
     >>> try:
-    ...     b.make_move(Location(algebraic='b8'), Location(algebraic='b5'))
+    ...     b.make_move(Location(algebraic='b1'), Location(algebraic='b4'))
     ... except IllegalMoveError as e:
     ...     print('Illegal move was attempted')
     Illegal move was attempted
     >>> b.who = Color.WHITE
-    >>> b.make_move(Location(algebraic='e7'), Location(algebraic='e6'))
+    >>> b.make_move(Location(algebraic='e2'), Location(algebraic='e3'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ _ ♙ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ _  5
-    6  _ _ _ _ ♙ _ _ _  6
-    7  ♙ _ ♙ _ _ _ ♙ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ ♝ ♛ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
+    6  _ _ _ _ _ _ _ _  6
+    5  ♟ _ _ ♙ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ _  4
+    3  _ _ _ _ ♙ _ _ _  3
+    2  ♙ _ ♙ _ _ _ ♙ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> ##b.get_piece_at(Location(algebraic='d8')).all_legal_moves
-    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='d8')).all_legal_moves))
-    ['d7', 'd6', 'd5', 'e7', 'f6', 'g5', 'h4', 'c8']
-    >>> b.get_piece_at(Location(algebraic='d8')).color.value
+    >>> ##b.get_piece_at(Location(algebraic='d1')).all_legal_moves
+    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='d1')).all_legal_moves))
+    ['d2', 'd3', 'd4', 'e2', 'f3', 'g4', 'h5', 'c1']
+    >>> b.get_piece_at(Location(algebraic='d1')).color.value
     0
-    >>> b.get_piece_at(Location(algebraic='d8')).color.name
+    >>> b.get_piece_at(Location(algebraic='d1')).color.name
     'WHITE'
     >>> b.castling_rights
     ['K', 'k', 'q']
     >>> b.check(Color.WHITE)
     False
-    >>> b.make_move(Location(algebraic='d1'), Location(algebraic='h5'))
+    >>> b.make_move(Location(algebraic='d8'), Location(algebraic='h4'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ ♝ _ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ _ ♙ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ _ _  6
-    7  ♙ _ ♙ _ _ _ ♙ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ ♝ _ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
+    6  _ _ _ _ _ _ _ _  6
+    5  ♟ _ _ ♙ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ _ _  3
+    2  ♙ _ ♙ _ _ _ ♙ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> b.check(Color.WHITE)
     True
@@ -364,103 +364,103 @@ def test():
     []
     []
     []
-    ['g6']
+    ['g3']
     []
     []
     []
-    ['e7', 'd7']
+    ['e2', 'd2']
     []
     []
     []
-    >>> b.make_move(Location(algebraic='g7'), Location(algebraic='g6'))
+    >>> b.make_move(Location(algebraic='g2'), Location(algebraic='g3'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ ♝ _ ♚ ♝ ♞ ♜  1
-    2  _ _ ♟ ♟ _ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ _ ♙ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ ♙ _  6
-    7  ♙ _ ♙ _ _ _ _ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ ♝ _ ♚ ♝ ♞ ♜  8
+    7  _ _ ♟ ♟ _ ♟ ♟ ♟  7
+    6  _ _ _ _ _ _ _ _  6
+    5  ♟ _ _ ♙ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ ♙ _  3
+    2  ♙ _ ♙ _ _ _ _ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> b.make_move(Location(algebraic='c2'), Location(algebraic='c4'))
+    >>> b.make_move(Location(algebraic='c7'), Location(algebraic='c5'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ ♝ _ ♚ ♝ ♞ ♜  1
-    2  _ _ _ ♟ _ ♟ ♟ ♟  2
-    3  _ _ _ _ _ _ _ _  3
-    4  ♟ _ ♟ ♙ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ ♙ _  6
-    7  ♙ _ ♙ _ _ _ _ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ ♝ _ ♚ ♝ ♞ ♜  8
+    7  _ _ _ ♟ _ ♟ ♟ ♟  7
+    6  _ _ _ _ _ _ _ _  6
+    5  ♟ _ ♟ ♙ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ ♙ _  3
+    2  ♙ _ ♙ _ _ _ _ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> b.make_move(Location(algebraic='d4'), Location(algebraic='c3'))
+    >>> b.make_move(Location(algebraic='d5'), Location(algebraic='c6'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ ♝ _ ♚ ♝ ♞ ♜  1
-    2  _ _ _ ♟ _ ♟ ♟ ♟  2
-    3  _ _ ♙ _ _ _ _ _  3
-    4  ♟ _ _ _ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ ♙ _  6
-    7  ♙ _ ♙ _ _ _ _ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ ♝ _ ♚ ♝ ♞ ♜  8
+    7  _ _ _ ♟ _ ♟ ♟ ♟  7
+    6  _ _ ♙ _ _ _ _ _  6
+    5  ♟ _ _ _ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ ♙ _  3
+    2  ♙ _ ♙ _ _ _ _ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
-    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='g6')).all_legal_moves))
-    ['h5']
-    >>> b.make_move(Location(algebraic='c1'), Location(algebraic='a3'))
+    >>> list(map(lambda t: t.algebraic, b.get_piece_at(Location(algebraic='g3')).all_legal_moves))
+    ['h4']
+    >>> b.make_move(Location(algebraic='c8'), Location(algebraic='a6'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ _ _ ♚ ♝ ♞ ♜  1
-    2  _ _ _ ♟ _ ♟ ♟ ♟  2
-    3  ♝ _ ♙ _ _ _ _ _  3
-    4  ♟ _ _ _ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ ♙ _  6
-    7  ♙ _ ♙ _ _ _ _ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ _ _ ♚ ♝ ♞ ♜  8
+    7  _ _ _ ♟ _ ♟ ♟ ♟  7
+    6  ♝ _ ♙ _ _ _ _ _  6
+    5  ♟ _ _ _ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ ♙ _  3
+    2  ♙ _ ♙ _ _ _ _ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> print(list(map(lambda t: t.algebraic, b.player_king(Color.BLACK).all_legal_moves)))
-    ['e2', 'd1', 'c1']
+    ['e7', 'd8', 'c8']
     >>> b2 = Board(b.fen_str)
-    >>> b.make_move(Location(algebraic='c3'), Location(algebraic='c2'))
+    >>> b.make_move(Location(algebraic='c6'), Location(algebraic='c7'))
     >>> print(b)
        a b c d e f g h
-    1  ♜ _ _ _ ♚ ♝ ♞ ♜  1
-    2  _ _ ♙ ♟ _ ♟ ♟ ♟  2
-    3  ♝ _ _ _ _ _ _ _  3
-    4  ♟ _ _ _ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ ♙ _  6
-    7  ♙ _ ♙ _ _ _ _ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ _ _ ♚ ♝ ♞ ♜  8
+    7  _ _ ♙ ♟ _ ♟ ♟ ♟  7
+    6  ♝ _ _ _ _ _ _ _  6
+    5  ♟ _ _ _ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ ♙ _  3
+    2  ♙ _ ♙ _ _ _ _ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> print(list(map(lambda t: t.algebraic, b.player_king(Color.BLACK).all_legal_moves)))
-    ['e2']
+    ['e7']
     >>> print(b2)
        a b c d e f g h
-    1  ♜ _ _ _ ♚ ♝ ♞ ♜  1
-    2  _ _ _ ♟ _ ♟ ♟ ♟  2
-    3  ♝ _ ♙ _ _ _ _ _  3
-    4  ♟ _ _ _ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ ♙ _  6
-    7  ♙ _ ♙ _ _ _ _ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  ♜ _ _ _ ♚ ♝ ♞ ♜  8
+    7  _ _ _ ♟ _ ♟ ♟ ♟  7
+    6  ♝ _ ♙ _ _ _ _ _  6
+    5  ♟ _ _ _ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ ♙ _  3
+    2  ♙ _ ♙ _ _ _ _ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     >>> b2.who = Color.BLACK
-    >>> b2.make_move(Location(algebraic='e1'), Location(algebraic='c1'))
+    >>> b2.make_move(Location(algebraic='e8'), Location(algebraic='c8'))
     >>> print(b2)
        a b c d e f g h
-    1  _ _ ♚ ♜ _ ♝ ♞ ♜  1
-    2  _ _ _ ♟ _ ♟ ♟ ♟  2
-    3  ♝ _ ♙ _ _ _ _ _  3
-    4  ♟ _ _ _ ♞ _ _ _  4
-    5  ♟ ♙ _ _ _ ♙ _ ♛  5
-    6  _ _ _ _ ♙ _ ♙ _  6
-    7  ♙ _ ♙ _ _ _ _ ♙  7
-    8  _ ♖ _ ♕ ♔ ♗ ♘ ♖  8
+    8  _ _ ♚ ♜ _ ♝ ♞ ♜  8
+    7  _ _ _ ♟ _ ♟ ♟ ♟  7
+    6  ♝ _ ♙ _ _ _ _ _  6
+    5  ♟ _ _ _ ♞ _ _ _  5
+    4  ♟ ♙ _ _ _ ♙ _ ♛  4
+    3  _ _ _ _ ♙ _ ♙ _  3
+    2  ♙ _ ♙ _ _ _ _ ♙  2
+    1  _ ♖ _ ♕ ♔ ♗ ♘ ♖  1
        a b c d e f g h
     """


### PR DESCRIPTION
The convention in chess algebraic notation is to have rows 1 & 2 be at the bottom of the board for white and 7 & 8 at the top of the board for black. Prior to these changes the rows in the algebraic notation were ordered from top to bottom. i.e. with white king pawn at e7 rather than the correct e2. This change set corrects this.

* chess.py 
  - fixed conversion of Location.row to/from algebraic row number
  - changed castling move generator based on revised algebraic notation

* tests.py 
  - changed tests to reflect revised algebraic notation